### PR TITLE
Add cv hedder

### DIFF
--- a/target_obejct_detector/include/target_object_detector.hpp
+++ b/target_obejct_detector/include/target_object_detector.hpp
@@ -37,6 +37,7 @@
 #include <pcl_ros/impl/transforms.hpp>
 
 #include <opencv/cv.h>
+#include <opencv2/imgproc/imgproc.hpp>
 
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 


### PR DESCRIPTION
これまで本パッケージを使用したことのない環境でビルドしたら下記エラーが出ました。

```
src/target_object_detector.cpp:202:27: error: ‘minAreaRect’ is not a member of ‘cv’
   cv::RotatedRect rrect = cv::minAreaRect(points_mat);
```

というわけで下記ヘッダーを加えたら事なきを得ました。

#include <opencv2/imgproc/imgproc.hpp>

Travisも通っています。